### PR TITLE
Move references validation to the latter stage

### DIFF
--- a/test-suites/src/commonTest/kotlin/io/github/optimumcode/json/schema/suite/AbstractSchemaTestSuite.kt
+++ b/test-suites/src/commonTest/kotlin/io/github/optimumcode/json/schema/suite/AbstractSchemaTestSuite.kt
@@ -133,7 +133,7 @@ private fun FunSpec.executeFromDirectory(
       JsonSchemaLoader.create()
         .apply {
           SchemaType.entries.forEach(::registerWellKnown)
-          for ((uri, schema) in remoteSchemas.entries.reversed()) {
+          for ((uri, schema) in remoteSchemas) {
             if (uri.contains("draft4", ignoreCase = true)) {
               // skip draft4 schemas
               continue


### PR DESCRIPTION
There is no guarantee that all schemes will be registered in the order of usage (schema with dependency after those dependencies). Because of that I have moved the references validation to the latter stage when the actual schema that will be used for validation is created