### PR TITLE
Add failFast flag in `flag` output to skip remaining validations after first failure

### DIFF
--- a/src/commonMain/kotlin/io/github/optimumcode/json/schema/OutputCollector.kt
+++ b/src/commonMain/kotlin/io/github/optimumcode/json/schema/OutputCollector.kt
@@ -93,6 +93,9 @@ public sealed class OutputCollector<T> private constructor(
 
   internal abstract fun onError(error: ValidationError)
 
+  internal open val isFailFast: Boolean
+    get() = false
+
   /**
    * A utility method that allows to call [reportErrors] method after the [block] has been executed
    */
@@ -116,6 +119,9 @@ public sealed class OutputCollector<T> private constructor(
   internal data object Empty : OutputCollector<Nothing>() {
     override val output: Nothing
       get() = throw UnsupportedOperationException("no output in empty collector")
+
+    override val isFailFast: Boolean
+      get() = true
 
     override fun updateLocation(path: JsonPointer): OutputCollector<Nothing> = this
 
@@ -193,6 +199,8 @@ public sealed class OutputCollector<T> private constructor(
   ) : OutputCollector<ValidationOutput.Flag>(parent, transformer) {
     private var valid: Boolean = true
     private var hasErrors: Boolean = false
+    override val isFailFast: Boolean
+      get() = true
     override val output: ValidationOutput.Flag
       get() =
         if (valid) {

--- a/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/JsonSchemaRoot.kt
+++ b/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/JsonSchemaRoot.kt
@@ -24,9 +24,13 @@ internal class JsonSchemaRoot(
     var result = true
     context.pushSchemaPath(schemaPath, scopeId)
     errorCollector.updateKeywordLocation(schemaPath).use {
+      val failFast = isFailFast
       assertions.forEach {
         val valid = it.validate(element, context, this)
         result = result and valid
+        if (!result && failFast) {
+          return@use
+        }
       }
     }
     context.popSchemaPath()


### PR DESCRIPTION
Resolves #136