### PR TITLE
Support `wasm` target

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ from [kotlinx.serialization-json](https://github.com/Kotlin/kotlinx.serializatio
 |-------------------|
 | jvm               |
 | js                |
+| wasmJs            |
 | macosX64          |
 | macosArm64        |
 | iosArm64          |

--- a/json-schema-validator/api/json-schema-validator.api
+++ b/json-schema-validator/api/json-schema-validator.api
@@ -354,7 +354,3 @@ public abstract interface class io/github/optimumcode/json/schema/extension/Exte
 	public abstract fun getSchemaPath ()Lio/github/optimumcode/json/pointer/JsonPointer;
 }
 
-public final class io/github/optimumcode/json/schema/internal/hostname/Normalizer_nonWasmJsKt {
-	public static final fun isNormalized (Ljava/lang/String;)Z
-}
-

--- a/json-schema-validator/api/json-schema-validator.api
+++ b/json-schema-validator/api/json-schema-validator.api
@@ -354,3 +354,7 @@ public abstract interface class io/github/optimumcode/json/schema/extension/Exte
 	public abstract fun getSchemaPath ()Lio/github/optimumcode/json/pointer/JsonPointer;
 }
 
+public final class io/github/optimumcode/json/schema/internal/hostname/Normalizer_nonWasmJsKt {
+	public static final fun isNormalized (Ljava/lang/String;)Z
+}
+

--- a/json-schema-validator/build.gradle.kts
+++ b/json-schema-validator/build.gradle.kts
@@ -145,6 +145,9 @@ kotlin {
     generateTypeScriptDefinitions()
     nodejs()
   }
+  wasmJs {
+    nodejs()
+  }
   applyDefaultHierarchyTemplate()
 
   val macOsTargets =
@@ -168,7 +171,7 @@ kotlin {
     )
 
   sourceSets {
-    commonMain {
+    val commonMain by getting {
       kotlin.srcDirs(generatedSourceDirectory)
 
       dependencies {
@@ -182,11 +185,33 @@ kotlin {
         ) {
           because("simplifies work with unicode codepoints")
         }
+      }
+    }
+
+    val wasmJsMain by getting {
+
+    }
+
+    val nonWasmJsMain by creating {
+      dependsOn(commonMain)
+
+      dependencies {
         implementation(libs.normalize.get().toString()) {
           because("provides normalization required by IDN-hostname format")
         }
       }
     }
+
+    val jvmMain by getting {
+      dependsOn(nonWasmJsMain)
+    }
+    val jsMain by getting {
+      dependsOn(nonWasmJsMain)
+    }
+    val nativeMain by getting {
+      dependsOn(nonWasmJsMain)
+    }
+
     commonTest {
       dependencies {
         implementation(libs.kotest.assertions.core)

--- a/json-schema-validator/build.gradle.kts
+++ b/json-schema-validator/build.gradle.kts
@@ -1,7 +1,10 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 import java.util.Locale
 
@@ -146,8 +149,10 @@ kotlin {
     nodejs()
   }
   wasmJs {
+    browser()
     nodejs()
   }
+
   applyDefaultHierarchyTemplate()
 
   val macOsTargets =

--- a/json-schema-validator/build.gradle.kts
+++ b/json-schema-validator/build.gradle.kts
@@ -189,7 +189,6 @@ kotlin {
     }
 
     val wasmJsMain by getting {
-
     }
 
     val nonWasmJsMain by creating {

--- a/json-schema-validator/build.gradle.kts
+++ b/json-schema-validator/build.gradle.kts
@@ -149,6 +149,8 @@ kotlin {
     nodejs()
   }
   wasmJs {
+    // The wasmJsBrowserTest prints all executed tests as one unformatted string
+    // Have not found a way to suppress printing all this into console
     browser()
     nodejs()
   }
@@ -193,8 +195,7 @@ kotlin {
       }
     }
 
-    val wasmJsMain by getting {
-    }
+    val wasmJsMain by getting
 
     val nonWasmJsMain by creating {
       dependsOn(commonMain)
@@ -282,6 +283,7 @@ kotlin {
       dependsOnTargetTests(linuxTargets)
       dependsOn(tasks.getByName("jvmTest"))
       dependsOn(tasks.getByName("jsTest"))
+      dependsOn(tasks.getByName("wasmJsTest"))
     }
   }
 }

--- a/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/formats/IdnHostnameFormatValidator.kt
+++ b/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/formats/IdnHostnameFormatValidator.kt
@@ -7,8 +7,8 @@ import io.github.optimumcode.json.schema.FormatValidator
 import io.github.optimumcode.json.schema.internal.formats.IdnHostnameFormatValidator.BidiLabelType.LTR
 import io.github.optimumcode.json.schema.internal.formats.IdnHostnameFormatValidator.BidiLabelType.NONE
 import io.github.optimumcode.json.schema.internal.formats.IdnHostnameFormatValidator.BidiLabelType.RTL
-import io.github.optimumcode.json.schema.internal.hostname.Normalizer
 import io.github.optimumcode.json.schema.internal.hostname.Punycode
+import io.github.optimumcode.json.schema.internal.hostname.isNormalized
 import io.github.optimumcode.json.schema.internal.unicode.CharacterCategory
 import io.github.optimumcode.json.schema.internal.unicode.CharacterCategory.ENCLOSING_MARK
 import io.github.optimumcode.json.schema.internal.unicode.CharacterCategory.NONSPACING_MARK
@@ -108,7 +108,7 @@ internal object IdnHostnameFormatValidator : AbstractStringFormatValidator() {
         label
       }
 
-    if (!Normalizer.isNormalized(unicode)) {
+    if (!isNormalized(unicode)) {
       return false
     }
 

--- a/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.kt
+++ b/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.kt
@@ -1,10 +1,3 @@
 package io.github.optimumcode.json.schema.internal.hostname
 
-import doist.x.normalize.Form
-import doist.x.normalize.normalize
-
-internal object Normalizer {
-  fun isNormalized(label: String): Boolean {
-    return label.normalize(Form.NFC) == label
-  }
-}
+public expect fun isNormalized(label: String): Boolean

--- a/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.kt
+++ b/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.kt
@@ -1,3 +1,3 @@
 package io.github.optimumcode.json.schema.internal.hostname
 
-public expect fun isNormalized(label: String): Boolean
+internal expect fun isNormalized(label: String): Boolean

--- a/json-schema-validator/src/nonWasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.nonWasmJs.kt
+++ b/json-schema-validator/src/nonWasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.nonWasmJs.kt
@@ -1,0 +1,8 @@
+package io.github.optimumcode.json.schema.internal.hostname
+
+import doist.x.normalize.Form
+import doist.x.normalize.normalize
+
+public actual fun isNormalized(label: String): Boolean {
+  return label.normalize(Form.NFC) == label
+}

--- a/json-schema-validator/src/nonWasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.nonWasmJs.kt
+++ b/json-schema-validator/src/nonWasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.nonWasmJs.kt
@@ -3,6 +3,6 @@ package io.github.optimumcode.json.schema.internal.hostname
 import doist.x.normalize.Form
 import doist.x.normalize.normalize
 
-public actual fun isNormalized(label: String): Boolean {
+internal actual fun isNormalized(label: String): Boolean {
   return label.normalize(Form.NFC) == label
 }

--- a/json-schema-validator/src/wasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.wasmJs.kt
+++ b/json-schema-validator/src/wasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.wasmJs.kt
@@ -1,0 +1,6 @@
+package io.github.optimumcode.json.schema.internal.hostname
+
+public actual fun isNormalized(label: String): Boolean {
+  // depending library does not yet support wasm: https://github.com/OptimumCode/json-schema-validator/issues/177#issuecomment-2268482409
+  return true
+}

--- a/json-schema-validator/src/wasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.wasmJs.kt
+++ b/json-schema-validator/src/wasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.wasmJs.kt
@@ -1,6 +1,6 @@
 package io.github.optimumcode.json.schema.internal.hostname
 
-public actual fun isNormalized(label: String): Boolean {
+internal actual fun isNormalized(label: String): Boolean {
   // depending library does not yet support wasm: https://github.com/OptimumCode/json-schema-validator/issues/177#issuecomment-2268482409
   return true
 }

--- a/json-schema-validator/src/wasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.wasmJs.kt
+++ b/json-schema-validator/src/wasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.wasmJs.kt
@@ -1,6 +1,3 @@
 package io.github.optimumcode.json.schema.internal.hostname
 
-internal actual fun isNormalized(label: String): Boolean {
-  // depending library does not yet support wasm: https://github.com/OptimumCode/json-schema-validator/issues/177#issuecomment-2268482409
-  return true
-}
+internal actual fun isNormalized(label: String): Boolean = js("label.normalize('NFC') === label")

--- a/test-suites/build.gradle.kts
+++ b/test-suites/build.gradle.kts
@@ -30,9 +30,7 @@ kotlin {
   js(IR) {
     nodejs()
   }
-  wasmJs {
-    nodejs()
-  }
+  // wasmJs target is not added because the okio does not provide a dependency to use FileSystem API in wasmJs target
   applyDefaultHierarchyTemplate()
 
   val macOsTargets =

--- a/test-suites/build.gradle.kts
+++ b/test-suites/build.gradle.kts
@@ -1,9 +1,6 @@
-@file:OptIn(ExperimentalWasmDsl::class)
-
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest

--- a/test-suites/build.gradle.kts
+++ b/test-suites/build.gradle.kts
@@ -1,6 +1,9 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
@@ -67,6 +70,10 @@ kotlin {
     jsTest {
       dependencies {
         implementation(libs.okio.nodefilesystem)
+      }
+    }
+    wasmJsTest {
+      dependencies {
       }
     }
     jvmTest {

--- a/test-suites/build.gradle.kts
+++ b/test-suites/build.gradle.kts
@@ -27,6 +27,9 @@ kotlin {
   js(IR) {
     nodejs()
   }
+  wasmJs {
+    nodejs()
+  }
   applyDefaultHierarchyTemplate()
 
   val macOsTargets =

--- a/test-suites/build.gradle.kts
+++ b/test-suites/build.gradle.kts
@@ -70,10 +70,6 @@ kotlin {
         implementation(libs.okio.nodefilesystem)
       }
     }
-    wasmJsTest {
-      dependencies {
-      }
-    }
     jvmTest {
       dependencies {
         implementation(libs.kotest.runner.junit5)


### PR DESCRIPTION
- update build setup to also include the `wasm` target
  - FIX https://github.com/OptimumCode/json-schema-validator/issues/177
  - adjust module hierarchy to not split wasm from other source sets as some dependency currently does not offer wasm support


*Note*
- The `wasm` target currently does not handle normalisation for `IDN-hostname format`