### PR TITLE
Avoid having shared mutable state between JsonSchema invocations

### DIFF
--- a/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/JsonSchema.kt
+++ b/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/JsonSchema.kt
@@ -3,7 +3,7 @@ package io.github.optimumcode.json.schema
 import io.github.optimumcode.json.pointer.JsonPointer
 import io.github.optimumcode.json.schema.OutputCollector.DelegateOutputCollector
 import io.github.optimumcode.json.schema.internal.DefaultAssertionContext
-import io.github.optimumcode.json.schema.internal.DefaultReferenceResolver
+import io.github.optimumcode.json.schema.internal.DefaultReferenceResolverProvider
 import io.github.optimumcode.json.schema.internal.IsolatedLoader
 import io.github.optimumcode.json.schema.internal.JsonSchemaAssertion
 import io.github.optimumcode.json.schema.internal.wrapper.wrap
@@ -18,7 +18,7 @@ import kotlin.jvm.JvmStatic
  */
 public class JsonSchema internal constructor(
   private val assertion: JsonSchemaAssertion,
-  private val referenceResolver: DefaultReferenceResolver,
+  private val referenceResolverProvider: DefaultReferenceResolverProvider,
 ) {
   /**
    * Validates [value] against this [JsonSchema].
@@ -56,7 +56,7 @@ public class JsonSchema internal constructor(
     value: AbstractElement,
     errorCollector: ErrorCollector,
   ): Boolean {
-    val context = DefaultAssertionContext(JsonPointer.ROOT, referenceResolver)
+    val context = DefaultAssertionContext(JsonPointer.ROOT, referenceResolverProvider.createResolver())
     return DelegateOutputCollector(errorCollector).use {
       assertion.validate(value, context, this)
     }
@@ -74,7 +74,7 @@ public class JsonSchema internal constructor(
     value: AbstractElement,
     outputCollectorProvider: OutputCollector.Provider<T>,
   ): T {
-    val context = DefaultAssertionContext(JsonPointer.ROOT, referenceResolver)
+    val context = DefaultAssertionContext(JsonPointer.ROOT, referenceResolverProvider.createResolver())
     val collector = outputCollectorProvider.get()
     collector.use {
       assertion.validate(value, context, this)

--- a/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/ReferenceResolver.kt
+++ b/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/ReferenceResolver.kt
@@ -22,6 +22,12 @@ internal class ReferenceHolder(
   operator fun component3(): Uri = scopeId
 }
 
+internal class DefaultReferenceResolverProvider(
+  private val references: Map<RefId, AssertionWithPath>,
+) {
+  fun createResolver(): DefaultReferenceResolver = DefaultReferenceResolver(references)
+}
+
 internal class DefaultReferenceResolver(
   private val references: Map<RefId, AssertionWithPath>,
   private val schemaPathsStack: ArrayDeque<Pair<JsonPointer, Uri>> = ArrayDeque(),

--- a/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/SchemaLoader.kt
+++ b/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/SchemaLoader.kt
@@ -289,7 +289,7 @@ private fun createSchema(result: LoadResult): JsonSchema {
       .asSequence()
       .filter { it.key in result.usedRefs || it.key in dynamicRefs }
       .associate { it.key to it.value }
-  return JsonSchema(result.assertion, DefaultReferenceResolver(usedReferencesWithPath))
+  return JsonSchema(result.assertion, DefaultReferenceResolverProvider(usedReferencesWithPath))
 }
 
 private class LoadResult(

--- a/json-schema-validator/src/commonTest/kotlin/io/github/optimumcode/json/schema/cuncurrency/ConcurrentExecutionTest.kt
+++ b/json-schema-validator/src/commonTest/kotlin/io/github/optimumcode/json/schema/cuncurrency/ConcurrentExecutionTest.kt
@@ -1,0 +1,65 @@
+package io.github.optimumcode.json.schema.cuncurrency
+
+import io.github.optimumcode.json.schema.JsonSchema
+import io.github.optimumcode.json.schema.OutputCollector
+import io.github.optimumcode.json.schema.SchemaType
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.time.Duration.Companion.milliseconds
+
+class ConcurrentExecutionTest : FunSpec() {
+  init {
+    val schema =
+      JsonSchema.Companion.fromDefinition(
+        """
+        {
+          "properties": {
+            "inner": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+        """.trimIndent(),
+        defaultType = SchemaType.DRAFT_2020_12,
+      )
+
+    test("BUG #224: JsonSchema can be used concurrently").config(coroutineTestScope = false) {
+      val target =
+        buildJsonObject {
+          put(
+            "inner",
+            buildJsonObject {
+              put("value", JsonPrimitive("test"))
+            },
+          )
+        }
+      shouldNotThrowAny {
+        coroutineScope {
+          withContext(Dispatchers.Default) {
+            repeat(1000) {
+              launch {
+                // delay is added to force suspension and increase changes of catching a concurrent issue within JsonSchema
+                delay(1.milliseconds)
+                val result = schema.validate(target, OutputCollector.Companion.flag())
+                result.valid.shouldBeTrue()
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Instead of having a shared reference resolver we now create a new one for each `validate` method invocation. This removes the shared mutable state when JsonSchema is invoked from multiple threads.

This change should not affect performance much as the reference resolver is created only once per `validate` method invocation.

Resolves #224