### PR TITLE
Move normalization logic back to common sources

### DIFF
--- a/json-schema-validator/build.gradle.kts
+++ b/json-schema-validator/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
   }
 
   sourceSets {
-    val commonMain by getting {
+    commonMain {
       dependencies {
         api(libs.kotlin.serialization.json)
         api(libs.uri)
@@ -36,28 +36,11 @@ kotlin {
         ) {
           because("simplifies work with unicode codepoints")
         }
-        implementation(libs.karacteristics)
-      }
-    }
-
-    val nonWasmJsMain by creating {
-      dependsOn(commonMain)
-
-      dependencies {
         implementation(libs.normalize.get().toString()) {
           because("provides normalization required by IDN-hostname format")
         }
+        implementation(libs.karacteristics)
       }
-    }
-
-    jvmMain {
-      dependsOn(nonWasmJsMain)
-    }
-    jsMain {
-      dependsOn(nonWasmJsMain)
-    }
-    nativeMain {
-      dependsOn(nonWasmJsMain)
     }
 
     commonTest {

--- a/json-schema-validator/build.gradle.kts
+++ b/json-schema-validator/build.gradle.kts
@@ -29,11 +29,7 @@ kotlin {
         api(libs.kotlin.serialization.json)
         api(libs.uri)
         // When using approach like above you won't be able to add because block
-        implementation(
-          libs.kotlin.codepoints
-            .get()
-            .toString(),
-        ) {
+        implementation(libs.kotlin.codepoints.get().toString()) {
           because("simplifies work with unicode codepoints")
         }
         implementation(libs.normalize.get().toString()) {

--- a/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.kt
+++ b/json-schema-validator/src/commonMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.kt
@@ -1,3 +1,8 @@
 package io.github.optimumcode.json.schema.internal.hostname
 
-internal expect fun isNormalized(label: String): Boolean
+import doist.x.normalize.Form
+import doist.x.normalize.normalize
+
+internal fun isNormalized(label: String): Boolean {
+  return label.normalize(Form.NFC) == label
+}

--- a/json-schema-validator/src/nonWasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.nonWasmJs.kt
+++ b/json-schema-validator/src/nonWasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.nonWasmJs.kt
@@ -1,8 +1,0 @@
-package io.github.optimumcode.json.schema.internal.hostname
-
-import doist.x.normalize.Form
-import doist.x.normalize.normalize
-
-internal actual fun isNormalized(label: String): Boolean {
-  return label.normalize(Form.NFC) == label
-}

--- a/json-schema-validator/src/wasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.wasmJs.kt
+++ b/json-schema-validator/src/wasmJsMain/kotlin/io/github/optimumcode/json/schema/internal/hostname/Normalizer.wasmJs.kt
@@ -1,3 +1,0 @@
-package io.github.optimumcode.json.schema.internal.hostname
-
-internal actual fun isNormalized(label: String): Boolean = js("label.normalize('NFC') === label")


### PR DESCRIPTION
After #278, the normalization library supports `wasmJs` target out-of-the-box and we can move the normalization logic back to common sources